### PR TITLE
fix: 修复行级代码块显示问题 #11

### DIFF
--- a/src/components/chat/index.tsx
+++ b/src/components/chat/index.tsx
@@ -88,6 +88,7 @@ export const Chat: FC<ChatProps> = (props) => {
                         const match =
                           /language-(\w+)/.exec(className || '') || []
                         return (
+                          !inline && match ? (
                           <div className={styles.codeBox}>
                             <SyntaxHighlighter
                               children={String(children).replace(/\n$/, '')}
@@ -98,6 +99,11 @@ export const Chat: FC<ChatProps> = (props) => {
                               {...props}
                             />
                           </div>
+                          ) : (
+                            <code className={className} {...props}>
+                              {children}
+                            </code>
+                          )
                         )
                       },
                     }}


### PR DESCRIPTION
as title. #11 

<img width="446" alt="image" src="https://user-images.githubusercontent.com/56359329/223982936-4bded748-7d55-409d-a114-4fe02d7bd496.png">
